### PR TITLE
Avoid dependency import in setup.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -14,7 +14,7 @@ Development Lead
 Contributors
 ~~~~~~~~~~~~
 
-None yet. Why not be the first?
+* Ben Homnick - https://github.com/bhomnick
 
 
 .. _DealerTrack GitHub: https://github.com/Dealertrack

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,6 @@ import re
 from setuptools import setup, find_packages
 
 
-module_file = open("skipnose/__init__.py").read()
-metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
-
-
 def read(fname):
     return (open(os.path.join(os.path.dirname(__file__), fname), 'rb')
             .read().decode('utf-8'))
@@ -19,6 +15,10 @@ authors = read('AUTHORS.rst')
 history = read('HISTORY.rst').replace('.. :changelog:', '')
 licence = read('LICENSE.rst')
 readme = read('README.rst')
+
+
+module_file = read("skipnose/__init__.py")
+metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
 
 
 requirements = read('requirements.txt').splitlines() + [

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, print_function
 import os
+import re
 from setuptools import setup, find_packages
 
-from skipnose import __author__, __email__, __version__
+
+module_file = open("skipnose/__init__.py").read()
+metadata = dict(re.findall("__([a-z]+)__\s*=\s*'([^']+)'", module_file))
 
 
 def read(fname):
@@ -17,19 +20,22 @@ history = read('HISTORY.rst').replace('.. :changelog:', '')
 licence = read('LICENSE.rst')
 readme = read('README.rst')
 
+
 requirements = read('requirements.txt').splitlines() + [
     'setuptools',
 ]
+
 
 test_requirements = (
     read('requirements.txt').splitlines()
     + read('requirements-dev.txt').splitlines()[1:]
 )
 
+
 setup(
     name='skipnose',
-    version=__version__,
-    author=__author__,
+    version=metadata['version'],
+    author=metadata['author'],
     description='Nose plugin which allows to include/exclude directories '
                 'for testing by their glob pattern.',
     long_description='\n\n'.join([readme, history, authors, licence]),


### PR DESCRIPTION
Installation will fail on a system that doesn't yet have nose installed due to importing nose in setup.py.